### PR TITLE
Fix old stuff

### DIFF
--- a/index.it.html
+++ b/index.it.html
@@ -96,18 +96,11 @@ pageTracker._trackPageview();
 <dl>
 <dt>PostgreSQL Day 2018</dt>
 <dd>
-<p>
-    La dodicesima edizione del PostgreSQL Day, la conferenza nazionale sul database open-source pi&ugrave; avanzato al mondo, si terr&agrave; il 28 e 29 Giugno 2018 presso il Lago di Garda.</p>
-
-<!--
-<strong>Procedi con la registrazione direttamente dal sito!</strong>
--->
+    <p>
+        <a href="http://www.pgday.it/">
+    Edizione corrente del PGDay.IT
+        </a>
 </p>
-
-<p>Per maggior informazioni:</p>
-<ul>
-<li><a href="http://www.pgday.it/">PGDay italiano 2018</a></li>
-</ul>
 
 </dd>
 

--- a/index.it.html
+++ b/index.it.html
@@ -132,42 +132,10 @@ pageTracker._trackPageview();
 <div id="home_release">
   <h2>Ultime <span lang="en" xml:lang="en">release</span> di Postgres</h2>
 
-  <ul class="release">
-  <li><strong>9.6.1:</strong>
-  <ul>
-  <li><a href="http://www.postgresql.org/ftp/source/v9.6.1" hreflang="en" title="Apri una nuova finestra da dove potrai scaricare i sorgenti della release 9.6.1 di PostgreSQL (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Sorgente</a>, </li>
-  <li><a href="http://www.postgresql.org/docs/9.6/static/release-9-6-1.html" hreflang="en" title="Apri una nuova finestra da dove potrai consultare le note di rilascio di PostgreSQL 9.5.3 (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Note</a></li>
-  </ul>
-  </li>
-
-  <li><strong>9.5.5:</strong>
-  <ul>
-  <li><a href="http://www.postgresql.org/ftp/source/v9.5.5" hreflang="en" title="Apri una nuova finestra da dove potrai scaricare i sorgenti della release 9.5.5 di PostgreSQL (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Sorgente</a>, </li>
-  <li><a href="http://www.postgresql.org/docs/9.5/static/release-9-5-5.html" hreflang="en" title="Apri una nuova finestra da dove potrai consultare le note di rilascio di PostgreSQL 9.5.5 (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Note</a></li>
-  </ul>
-  </li>
-
-  <li><strong>9.4.10:</strong>
-  <ul>
-  <li><a href="http://www.postgresql.org/ftp/source/v9.4.10" hreflang="en" title="Apri una nuova finestra da dove potrai scaricare i sorgenti della release 9.4.10 di PostgreSQL (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Sorgente</a>, </li>
-  <li><a href="http://www.postgresql.org/docs/9.4/static/release-9-4-10.html" hreflang="en" title="Apri una nuova finestra da dove potrai consultare le note di rilascio di PostgreSQL 9.3.13 (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Note</a></li>
-  </ul>
-  </li>
-
-  <li><strong>9.3.15:</strong>
-  <ul>
-  <li><a href="http://www.postgresql.org/ftp/source/v9.3.15" hreflang="en" title="Apri una nuova finestra da dove potrai scaricare i sorgenti della release 9.3.15 di PostgreSQL (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Sorgente</a>, </li>
-  <li><a href="http://www.postgresql.org/docs/9.3/static/release-9-3-15.html" hreflang="en" title="Apri una nuova finestra da dove potrai consultare le note di rilascio di PostgreSQL 9.3.15 (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Note</a></li>
-  </ul>
-  </li>
-
-  <li><strong>9.2.19:</strong>
-  <ul>
-  <li><a href="http://www.postgresql.org/ftp/source/v9.2.19" hreflang="en" title="Apri una nuova finestra da dove potrai scaricare i sorgenti della release 9.2.19 di PostgreSQL (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Sorgente</a>, </li>
-  <li><a href="http://www.postgresql.org/docs/9.2/static/release-9-2-19.html" hreflang="en" title="Apri una nuova finestra da dove potrai consultare le note di rilascio di PostgreSQL 9.2.19 (in inglese)" onclick="javascript: window.open(this.href); return false;" onkeypress="javascript: window.open(this.href); return false;">Note</a></li>
-  </ul>
-  </li>
-  </ul>
+  <p>
+      Per scaricare l'ultima release di PostgreSQL consulta direttamente la pagina
+      <a href="https://www.postgresql.org/download/"> di download ufficiale</a>.
+  </p>
 </div>
 
 <!--div id="home_release">

--- a/index.it.html
+++ b/index.it.html
@@ -94,12 +94,14 @@ pageTracker._trackPageview();
 
 <div id="home_highlight">
 <dl>
-<dt>PostgreSQL Day 2018</dt>
+<dt>PostgreSQL Day</dt>
 <dd>
     <p>
+        Il PostgreSQL Day, conosciuto anche come <strong>PGDay.IT</strong> e&grave; la giornata nazionale dedicata a questo favoloso database Open Source. ITPUG si occupa dell'organizzazione dell'evento. Per maggiori informazioni consulta il sito web relativo alla
         <a href="http://www.pgday.it/">
-    Edizione corrente del PGDay.IT
+    edizione corrente del PGDay.IT
         </a>
+        .
 </p>
 
 </dd>

--- a/index.it.html
+++ b/index.it.html
@@ -105,27 +105,18 @@ pageTracker._trackPageview();
 </dd>
 
 
-<dt>Passate edizioni:</dt>
+<dt>Alcune delle precedenti edizioni:</dt>
 <dd>
 
-    <p>
-        <b>PostgreSQL Day 2017</b>
-        L'undicesime edizione del PostgreSQL Day, la conferenza nazionale sul database open-source pi&ugrave; avanzato al mondo, si &egrave; tenuta il 13 Ottobre 2017 a Milano.</p>
-    <p><Pe></Pe>r maggior informazioni:</p>
     <ul>
-        <li><a href="http://2017.pgday.it/">PGDay.IT italiano 2017</a></li>
+        <li><a href="http://2017.pgday.it/">2017</a></li>
+        <li><a href="http://2016.pgday.it/">2016</a></li>
+        <li><a href="http://2015.pgday.it/">2015</a></li>
+        <li><a href="http://2014.pgday.it/">2014</a></li>
+        <li><a href="http://2013.pgday.it/">2013</a></li>
     </ul>
 
 <p>
-<b>PostgreSQL Day 2016</b>
-La decima edizione del PostgreSQL Day, la conferenza nazionale sul database open-source pi&ugrave; avanzato al mondo, si &egrave; svolta lo scorso 13 Dicembre 2016 a Prato.</p>
-
-</p>
-
-<p>Per maggior informazioni:</p>
-<ul>
-<li><a href="http://2016.pgday.it/">PGDay.IT italiano 2016</a></li>
-</ul>
 
 </dd>
 </dl>

--- a/index.it.html
+++ b/index.it.html
@@ -75,7 +75,7 @@ pageTracker._trackPageview();
 		<li><a href="http://www.itpug.org/association/index.it.html" title="vai al documento riguardante 'L'associazione Italian PostgreSQL Users Group'">Associazione</a></li>
 <li><a href="http://www.itpug.org/postgresql/index.it.html" title="vai al documento riguardante 'PostgreSQL'">PostgreSQL</a></li>
 <li><a href="http://docs.itpug.org/" title="vai al documento riguardante 'Documentazione di PostgreSQL'">Documentazione</a></li>
-<li><a href="http://www.pgday.it"" title="vai al documento riguardante 'Il PostgreSQL Day, la giornata nazionale di PostgreSQL'">PGday.IT</a></li>
+<li><a href="http://www.pgday.it"" title="vai al documento riguardante 'Il PostgreSQL Day, la giornata nazionale di PostgreSQL'">PGDay.IT</a></li>
 <li><a href="http://www.itpug.org/chapter/index.it.html" title="vai al documento riguardante 'I chapter dell'associazione sul territorio italiano'">Chapter</a></li>
 <li><a href="http://www.itpug.org/eventi/index.it.html" title="vai al documento riguardante 'Gli eventi a cui ha partecipato o parteciper&agrave; ITPUG'">Eventi</a></li>
 <li><a href="http://www.itpug.org/download/index.it.html" title="vai al documento riguardante 'Download di materiale informativo e software basato inerenti PostgreSQL'">Download</a></li>

--- a/thanks/index.it.html
+++ b/thanks/index.it.html
@@ -90,9 +90,7 @@ pageTracker._trackPageview();
 
 <dl>
 <dt><a href="http://www.devise.it/">Devise.IT</a></dt>
-<dd>
-Il sito di ITPUG &egrave; parzialmente ospitato all'interno di una struttura offerta dall'azienda Devise.IT di Prato.
-</dd>
+
 
 <dt><a href="http://print24.com/it/">Print24 Stampa di volantini online.</a></dt>
 <dd>


### PR DESCRIPTION
Rimosso il riferimento al pgday 2018 (passato) poiché il link punta già al sito 2019.
Rimosse anche le passate edizioni dal sito, non erano assolutamente aggiornate.